### PR TITLE
fixing hot reload

### DIFF
--- a/BuildTools/docker-compose.yml
+++ b/BuildTools/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       timeout: 2s
       retries: 200
     volumes:
+      - ./mysql:/docker-entrypoint-initdb.d
       - type: volume
         source: dbdata
         target: /var/lib/mysql
@@ -40,6 +41,8 @@ services:
           nocopy: true
     networks:
       - private
+    depends_on:
+      - stocksdb
   phpmyadmin:
     image: phpmyadmin
     restart: always
@@ -92,7 +95,8 @@ services:
     networks:
       - public
     environment:
-      - CHOKIDAR_USEPOLLING=true
+      - WATCHPACK_POLLING=true
+      - WDS_SOCKET_PORT=8890
     # depends_on:
     #   backend:
     #     condition: service_healthy

--- a/BuildTools/mysql/01-databases.sql
+++ b/BuildTools/mysql/01-databases.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS test_stocksapp;
+
+GRANT ALL PRIVILEGES ON test_stocksapp.* TO 'team2'@'%';


### PR DESCRIPTION
making redis rely on the database
adding mariadb init
- this is to enable the test db creation and access for django unit tests