### PR TITLE
adding pycoverage tests

### DIFF
--- a/.github/workflows/pycode-coverage.yml
+++ b/.github/workflows/pycode-coverage.yml
@@ -26,7 +26,7 @@ jobs:
             MYSQL_PORT=3306
             MYSQL_ROOT_PASSWORD=unittestrootpw
             MYSQL_DATABASE=stocksapp
-            MYSQL_USER=unittestuser
+            MYSQL_USER=team2
             MYSQL_PASSWORD=unittestMysqlP@ssword
             MYSQL_PWD=unittestMysqlP@ssword
         EOF

--- a/.github/workflows/pycode-coverage.yml
+++ b/.github/workflows/pycode-coverage.yml
@@ -1,0 +1,41 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: NTSS Code Coverage
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v3
+    - name: Setup Env Vars
+      run: |
+        cat >> .envvars << EOF
+            DJANGO_SECRET_KEY='django-insecure-4o3ug_h7f1r6fa2z5@4o3ug_h7f1r6fa2-!x=-n*tfuccxn5n'
+            MYSQL_HOST=stocksdb
+            MYSQL_PORT=3306
+            MYSQL_ROOT_PASSWORD=unittestrootpw
+            MYSQL_DATABASE=stocksapp
+            MYSQL_USER=unittestuser
+            MYSQL_PASSWORD=unittestMysqlP@ssword
+            MYSQL_PWD=unittestMysqlP@ssword
+        EOF
+    - name: Compose docker
+      run: |
+        docker compose -f BuildTools/docker-compose.yml up -d --build --remove-orphans
+    - name: Test with coverage
+      run: |
+        docker exec stocks_backend /bin/bash -c 'source /var/local/bin/stocks_venv/bin/activate; coverage run manage.py test --keepdb'
+    - name: Output results
+      run: |
+        docker exec stocks_backend /bin/bash -c 'source /var/local/bin/stocks_venv/bin/activate; coverage report -m'

--- a/django/stocks/management/utils.py
+++ b/django/stocks/management/utils.py
@@ -4,10 +4,11 @@ This should be used for utility aspects only
 from django.core.cache import cache
 from django.http import JsonResponse
 
-def clear_cache() -> None:
+def clear_cache(request) -> None:
     """
     Clears the redis cache
     """
+    print(request)
     results = {'error': 'Unable to clear cache'}
     if cache.clear():
         results = {'msg': 'Cache Cleared'}

--- a/django/stocks/tests/test_views.py
+++ b/django/stocks/tests/test_views.py
@@ -1,24 +1,53 @@
-from django.test import TestCase
-from django.http import JsonResponse
+import json
+from django.test import RequestFactory, TestCase
 
 from stocks import views
 
 # Create your tests here.
-class StockTests(TestCase):
-    component = None
-    resp = None
+class StockTestCases(TestCase):
+    symbol = None
 
-    def setup(self) -> None:
-        self.component = views()
-        self.resp = self.component.get_ticker('amzn')
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.symbol = 'AMZN'
 
     def tearDown(self) -> None:
         return super().tearDown()
 
     def test_find_ticker(self):
-        self.setUp()
+        request = self.factory.get('/stocks/find/amazon')
+        self.resp = views.find_ticker(request)
+        self.assertIsNotNone(self.resp)
         self.assertEqual(self.resp.status_code, 200)
-        json_resp = self.resp.json()
+        json_resp = json.loads(self.resp.content)
         self.assertEqual(json_resp['count'], 7)
-        self.assertIn(json_resp, 'quotes')
-        self.assertIn(json_resp['quotes'][0]['symbol'], 'AMZN')
+        self.assertIn('quotes', json_resp)
+        self.assertEqual(len(json_resp['quotes']), 7)
+        self.assertIn('symbol', json_resp['quotes'][0])
+        self.assertIn(json_resp['quotes'][0]['symbol'], self.symbol)
+
+    def test_get_ticker_news(self):
+        request = self.factory.get(f'/stocks/{self.symbol}/news')
+        resp = views.get_ticker_news(request)
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, 200)
+        json_resp = json.loads(resp.content)
+        self.assertEqual(json_resp['count'], 20)
+        count = json_resp['count']
+        self.assertIn('news', json_resp)
+        self.assertEqual(len(json_resp['news']), count)
+        self.assertIn('type', json_resp['news'][0])
+        self.assertIn(json_resp['news'][0]['type'], ['STORY'])
+    
+    def test_get_ticker_metrics(self):
+        request = self.factory.get(f'/stocks/{self.symbol}')
+        resp = views.get_ticker(request, self.symbol)
+        self.assertIsNotNone(resp)
+        self.assertEqual(resp.status_code, 200)
+        json_resp = json.loads(resp.content)
+        self.assertIn('chart', json_resp)
+        self.assertIn('error', json_resp['chart'])
+        self.assertIsNone(json_resp['chart']['error'])
+        self.assertIn('result', json_resp['chart'])
+        result = json_resp['chart']['result'][0]
+        self.assertEqual(result['meta']['symbol'], self.symbol)

--- a/django/stocks/tests/test_views.py
+++ b/django/stocks/tests/test_views.py
@@ -51,3 +51,4 @@ class StockTestCases(TestCase):
         self.assertIn('result', json_resp['chart'])
         result = json_resp['chart']['result'][0]
         self.assertEqual(result['meta']['symbol'], self.symbol)
+        self.assertEqual(result['meta']['symbol'], f'{self.symbol}s')

--- a/django/stocks/tests/test_views.py
+++ b/django/stocks/tests/test_views.py
@@ -51,4 +51,3 @@ class StockTestCases(TestCase):
         self.assertIn('result', json_resp['chart'])
         result = json_resp['chart']['result'][0]
         self.assertEqual(result['meta']['symbol'], self.symbol)
-        self.assertEqual(result['meta']['symbol'], f'{self.symbol}s')

--- a/django/stocks/views.py
+++ b/django/stocks/views.py
@@ -71,7 +71,8 @@ class YahooFinance:
         if endtime:
             params['endtime'] = endtime
         query_params = self.build_params(params)
-        query_uri = f'{self.base_url.replace("/v1/", "/v8/")}chart/{ticker}?interval={interval}{query_params}'
+        base_url = self.base_url.replace("/v1/", "/v8/")
+        query_uri = f'{base_url}chart/{ticker}?interval={interval}{query_params}'
         return self.__make_request(query_uri)
 
     def __make_request(self, query_uri) -> dict:

--- a/django/stocks/views.py
+++ b/django/stocks/views.py
@@ -71,7 +71,7 @@ class YahooFinance:
         if endtime:
             params['endtime'] = endtime
         query_params = self.build_params(params)
-        query_uri = f'{self.base_url}chart/{ticker}?interval={interval}{query_params}'
+        query_uri = f'{self.base_url.replace("/v1/", "/v8/")}chart/{ticker}?interval={interval}{query_params}'
         return self.__make_request(query_uri)
 
     def __make_request(self, query_uri) -> dict:
@@ -85,7 +85,7 @@ class YahooFinance:
         )
         if r.status_code != 200:
             bad_result = {
-                'error': 'Failed retrieving reponse from Yahoo Finance',
+                'error': f'Failed retrieving reponse from Yahoo Finance for {query_uri}',
                 'status_code': r.status_code
             }
             return bad_result


### PR DESCRIPTION
Adding Pytests for the Stocks endpoint

Making pycoverage run within Github
Adding request to the cache_clear function.  Since we're calling it from an API endpoint, it needs to retrieve that first parameter

Had to fix the charting API call which uses the v8 API instead of v1 for yahoo