### PR TITLE
Making updates to have pagination work

### DIFF
--- a/reactjs/src/components/Pagination.js
+++ b/reactjs/src/components/Pagination.js
@@ -1,43 +1,37 @@
 import React from 'react';
 
-export default function Pagination({ currentPage, totalPages, onPageChange, itemsPerPage, totalItems }) {
-    // Function to handle clicking on the previous page button
-    const handlePreviousPage = () => {
-        console.log("Previous button clicked");
-        if (currentPage > 1) {
-            onPageChange(currentPage - 1); // Go to the previous page
+export default function Pagination(props) {
+    // Function to handle clicking on the previous or next page button
+    const handlePage = (direction, event) => {
+        if (direction === 'next'){
+            if (props.links.next != null) {
+                props.onPageChange(props.links.next); // Go to the next page
+            }
+        } else { // previous
+            if (props.links.previous != null) {
+                props.onPageChange(props.links.previous); // Go to the previous page
+            }
         }
-    };
-
-    // Function to handle clicking on the next page button
-    const handleNextPage = () => {
-        console.log("Next button clicked");
-        if (currentPage < totalPages) {
-            onPageChange(currentPage + 1); // Go to the next page
+        const target_element = document.getElementById(props.target_element);
+        if (target_element) {
+            target_element.scrollIntoView({ behavior: 'smooth' });
         }
-    };
-
-    // Calculate start and end indices of items to display on the current page
-    const startIndex = (currentPage - 1) * itemsPerPage;
-    const endIndex = Math.min(startIndex + itemsPerPage, totalItems);
+        event.target.blur() // remove the focus of the button that was clicked
+    }
 
     // Render pagination component
     return (
         <nav>
             <ul className="pagination">
                 {/* Previous page button */}
-                <li className={`page-item ${currentPage === 1 ? 'disabled' : ''}`}>
-                    <button className="page-link" onClick={handlePreviousPage}>Previous</button>
+                <li className={`page-item ${props.links.previous === null ? 'disabled' : ''}`}>
+                    <button className="page-link" onClick={(event) => handlePage('previous', event)}>Previous</button>
                 </li>
                 {/* Next page button */}
-                <li className={`page-item ${currentPage === totalPages || totalPages === 1 ? 'disabled' : ''}`}>
-                    <button className="page-link" onClick={handleNextPage}>Next</button>
+                <li className={`page-item ${props.links.next === null ? 'disabled' : ''}`}>
+                    <button className="page-link" onClick={(event) => handlePage('next', event)}>Next</button>
                 </li>
             </ul>
-            {/* Display current range of items */}
-            <div>
-                Showing items {startIndex + 1} to {endIndex} of {totalItems}
-            </div>
         </nav>
     );
 }

--- a/reactjs/src/pages/blocks/header.js
+++ b/reactjs/src/pages/blocks/header.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Header(props){
     return (
-        <header className="col-12 sticky-top bg-dark flex-md-nowrap p-3">
+        <header className="col-12 bg-dark flex-md-nowrap p-3">
             <h1 className="text-white">{props.sitename}</h1>
             <h4 className="text-white">{props.tagline}</h4>
         </header>

--- a/reactjs/src/pages/rule.js
+++ b/reactjs/src/pages/rule.js
@@ -33,6 +33,7 @@ export function SHOW_RULE(props) {
                     break;
                 case 404:
                     showToastError('Record not found to delete')
+                    break;
                 default:
                     break;
             }
@@ -139,7 +140,6 @@ export function SHOW_RULE(props) {
                 return ('<=')
             default:
                 return ('=')
-                break;
         }
     }
 
@@ -460,17 +460,19 @@ export function CREATE_RULE(props){
         catch (error) {
             if (error.response && error.response.status === 409) {
                 setErrorMessage("Rule already exists");
+                console.log(errorMessage);
             } else {
                 setErrorMessage(`${error.response.status}: ${error}`);
+                console.log(errorMessage);
             }
         }
     };
 
     const handleChange = (e) => {
         console.log(e.target.name)
-        if (['name'].indexOf(e.target.name) != -1 ){
+        if (['name'].indexOf(e.target.name) !== -1 ){
             setFormData({ ...formData, [e.target.name]: e.target.value });
-        } else if (['initial_investment'].indexOf(e.target.name) != -1 ){
+        } else if (['initial_investment'].indexOf(e.target.name) !== -1 ){
             setFormData({ ...formData, [e.target.name]: e.target.value + '.00' });
         } else {
             // parse the rule to a json rule

--- a/reactjs/src/pages/rules.js
+++ b/reactjs/src/pages/rules.js
@@ -45,7 +45,7 @@ export default function LIST_RULES(props) {
         } else {
             fetchRules();
         }
-    }, [fetchRules]);
+    }, [fetchRules, django_url]);
 
     // Function to handle page change
     const handlePageChange = (link) => {

--- a/reactjs/src/pages/rules.js
+++ b/reactjs/src/pages/rules.js
@@ -1,31 +1,33 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { AddCircleOutlineOutlined } from '@mui/icons-material';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
-import { Form } from 'react-bootstrap';
+import { Form, Spinner } from 'react-bootstrap';
+import { AddCircleOutlineOutlined } from '@mui/icons-material';
 import Pagination from '../components/Pagination'; // Import the Pagination component
 
 export default function LIST_RULES(props) {
-    const { get_auth_header, django_url = 'http://localhost:8889' } = props;
+    const { get_auth_header, django_url } = props;
 
     // State variables
     const [rules, setRules] = useState(null); // State for storing rules data
+    const [links, setLinks] = useState(null); // Sets the prev/next links
     const [loading, setLoading] = useState(true); // State for loading status
     const [error, setError] = useState(null); // State for error handling
-    const [currentPage, setCurrentPage] = useState(1); // State for current page number
-    const [totalPages, setTotalPages] = useState(1); // State for total number of pages
 
     // Function to fetch rules data
-    const fetchRules = useCallback(async () => {
+    const fetchRules = useCallback(async (link) => {
         try {
+            if (link === undefined){
+                link = `${django_url}/rules/list/`
+            }
             const headers = get_auth_header();
             // Fetch rules data from the server based on current page
-            const response = await axios.get(`${django_url}/rules/list/?page=${currentPage}`, { headers });
+            const response = await axios.get(link, { headers });
 
             // Check response status
             if (response.status === 200) {
                 setRules(response.data.records); // Set rules data
-                setTotalPages(response.data.total_pages); // Set total number of pages
+                setLinks(response.data.links);
             } else {
                 setError('Unexpected response status'); // Handle unexpected response status
             }
@@ -34,16 +36,20 @@ export default function LIST_RULES(props) {
         } finally {
             setLoading(false); // Update loading status
         }
-    }, [get_auth_header, django_url, currentPage]);
+    }, [get_auth_header, django_url]);
 
     // Effect to fetch rules data when currentPage changes
     useEffect(() => {
-        fetchRules();
-    }, [fetchRules, currentPage]);
+        if (django_url === undefined){
+            setLoading(true);
+        } else {
+            fetchRules();
+        }
+    }, [fetchRules]);
 
     // Function to handle page change
-    const handlePageChange = (page) => {
-        setCurrentPage(page); // Update currentPage
+    const handlePageChange = (link) => {
+        fetchRules(link); // Update currentPage
     };
 
     // Component to render individual rule
@@ -56,12 +62,12 @@ export default function LIST_RULES(props) {
     }
 
     // Component to display rules
-    function DisplayRule({ rules }) {
+    function DisplayRules({ rules }) {
         // Check if rules exist or empty
         if (!rules || rules.length === 0) return <div>No rules found.</div>;
 
         return (
-            <div>
+            <>
                 {rules.map(rule => (
                     <div className='row border border-light border-2 shadow-sm mb-5' key={rule.id}>
                         <div className='col-md-3'>
@@ -93,13 +99,26 @@ export default function LIST_RULES(props) {
                         </div>
                     </div> 
                 ))}
-            </div>
+            </>
         );
-    }    
+    }
 
-    // Slice rules based on currentPage
-    const slicedRules = rules ? rules.slice((currentPage - 1) * 8, currentPage * 8) : null;
+    if (loading) {
+        return (
+            <div>
+                <Spinner animation="border" variant="primary" />
+            </div>
+        )
+    }
 
+    // Component to render error state
+    if (error) {
+        return <div>Error: {error}</div>;
+    }
+
+
+    // // Slice rules based on currentPage
+    // const slicedRules = rules ? rules.slice((currentPage - 1) * 8, currentPage * 8) : null;
     // Render component
     return (
         <>
@@ -122,13 +141,14 @@ export default function LIST_RULES(props) {
                         </div>
                     </div>
                 </div>
-                {/* Display sliced rules */}
-                <DisplayRule rules={slicedRules} />
-                <Pagination
-                    currentPage={currentPage}
-                    totalPages={totalPages}
-                    onPageChange={handlePageChange} // Pass the handlePageChange function as prop
-                />
+                <div id='displayRules'>
+                    <DisplayRules rules={rules} />
+                    <Pagination
+                        onPageChange={handlePageChange} // Pass the handlePageChange function as prop
+                        links={links}
+                        target_element='displayRules'
+                    />
+                </div>
             </div>
         </>
     );


### PR DESCRIPTION
When calling pagination we should be using props
We can't calculate total pages, so that was removed. Current Page was also removed
The handlePreviousPage and handleNextPage were merged into one function Added functionality that on the page change the top of the target element is scrolled into view Also made the button lose focus
Using the links.previous and links.next to determine which page to go to next Removed sticky-top from the header, when using scrollintoview, the header causes the first row or two to be covered up adding a state for the links
in fetchRules passing the link that we should be going to with the default being the list page removing unneeded variables
changing references to page to just be link
created a wrapper for displayRules to make it targeted to scroll to Added loading and error displays
Added logic into useEffect, so if django_url is undefined that it will stay in a loading state and the fetchRules funciton is not called