### PR TITLE
Update dependabot.yml to run monthly rather than weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,19 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/reactjs/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/BuildTools/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/reactjs/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Rather than having dependabot check for old dependencies every week, moved this to a monthly cadence.